### PR TITLE
fix: set correct Avalanche Fuji USDC contract address

### DIFF
--- a/src/data/chains/43113/chain.ts
+++ b/src/data/chains/43113/chain.ts
@@ -43,7 +43,7 @@ export const avalancheFuji: TChain = {
     {
       code: "USDC",
       icon: usdcIcon,
-      address: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+      address: "0x5425890298aed601595a70AB815c96711a31Bc65",
       decimals: 6,
       canVote: true,
       priceSource: {


### PR DESCRIPTION
# Update USDC Token Address for Avalanche Fuji Testnet

## Description

This PR updates the USDC token address for the Avalanche Fuji testnet in the chain configuration file.

## Changes

- Updated the USDC token address from `0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E` to `0x5425890298aed601595a70AB815c96711a31Bc65` in the Avalanche Fuji testnet configuration.

## Reason for Change

The USDC token address for the Avalanche Fuji testnet has been updated to reflect the correct contract address for this specific network. The current address is the same as in the Avalanche mainnet configuration, but that is incorrect.

#### New address in the explorer
This is a contract address:
https://subnets-test.avax.network/c-chain/address/0x5425890298aed601595a70AB815c96711a31Bc65

#### Current address in the explorer
This **is not** a contract address:
https://subnets-test.avax.network/c-chain/address/0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E
