### PR TITLE
update redstone ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitcoin/gitcoin-chain-data",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/data/chains/10/chain.ts
+++ b/src/data/chains/10/chain.ts
@@ -43,7 +43,7 @@ export const optimism: TChain = {
         chainId: 10,
         address: "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
       },
-      redstoneTokenId: "USDGLO",
+      redstoneTokenId: "CUSD", // USDGLO not supported by Redstone. So setting the price temporrarily to CUSD
     },
     {
       code: "GIST",

--- a/src/data/chains/137/chain.ts
+++ b/src/data/chains/137/chain.ts
@@ -76,7 +76,7 @@ export const polygon: TChain = {
         chainId: 10,
         address: "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
       },
-      redstoneTokenId: "USDGLO",
+      redstoneTokenId: "CUSD", // USDGLO not supported by Redstone. So setting the price temporrarily to CUSD
     },
   ],
   subscriptions: [

--- a/src/data/chains/42161/chain.ts
+++ b/src/data/chains/42161/chain.ts
@@ -60,7 +60,7 @@ export const arbitrum: TChain = {
         chainId: 42161,
         address: "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
       },
-      redstoneTokenId: "USDGLO",
+      redstoneTokenId: "CUSD", // USDGLO not supported by Redstone. So setting the price temporrarily to CUSD
     },
     {
       code: "ETH",

--- a/src/data/chains/42220/chain.ts
+++ b/src/data/chains/42220/chain.ts
@@ -53,7 +53,7 @@ export const celoMainnet: TChain = {
         chainId: 42220,
         address: "0x765de816845861e75a25fca122bb6898b8b1282a",
       },
-      redstoneTokenId: "CSDC",
+      redstoneTokenId: "CUSD",
     },
     {
       code: "USDGLO",
@@ -65,7 +65,7 @@ export const celoMainnet: TChain = {
         chainId: 42220,
         address: "0x4f604735c1cf31399c6e711d5962b2b3e0225ad3",
       },
-      redstoneTokenId: "USDGLO",
+      redstoneTokenId: "CUSD", // USDGLO not supported by Redstone. So setting the price temporrarily to CUSD
     },
   ],
   subscriptions: [


### PR DESCRIPTION
fixes PAR-566

info: Since USDGLO is not available on Redstone and accurate pricing is not critical in this context, we have replaced the Redstone token ID for USDGLO with CUSD. This ensures a similar approximation in price.